### PR TITLE
Revamp welcome page into hero intro

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,7 +69,7 @@
         location.replace("#/dashboard");
         return;
       }
-      if (!this.state.profile && hash !== "#/welcome") {
+      if (!this.state.profile && hash === "#/dashboard") {
         location.replace("#/welcome");
         return;
       }
@@ -99,87 +99,57 @@
       }
     },
     renderWelcome() {
-      const profile = this.state.profile || {};
       this.appEl.innerHTML = `
-        <section class="card">
-          <div class="banner">
-            <h1>Планирование свадьбы без стресса</h1>
-            <p>Российская версия Bridebook поможет вам подобрать подрядчиков, отслеживать бюджет и подготовиться к идеальному дню. Начните с короткого теста — сервис подстроит подборки под ваши ответы.</p>
+        <section class="card welcome">
+          <div class="welcome-layout">
+            <div class="welcome-content">
+              <h1>Планирование свадьбы без стресса</h1>
+              <p class="welcome-subtitle">Подберём подрядчиков, поможем с бюджетом и сроками — всё в одном месте. Пройдите короткий тест, и мы настроим рекомендации под вашу пару.</p>
+              <button type="button" id="start-quiz">Начать тест</button>
+              <p class="welcome-note">Это бесплатно. Прогресс сохраняется.</p>
+            </div>
+            <div class="welcome-hero" role="presentation">
+              <img src="https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=1200&q=80" alt="Счастливая пара на фоне горного озера" loading="lazy" decoding="async">
+            </div>
           </div>
-          <form id="welcome-form" novalidate>
-            <div>
-              <label for="groom-name">Имя жениха</label>
-              <input id="groom-name" name="groomName" type="text" required placeholder="Иван" value="${profile.groomName ? profile.groomName : ""}">
-            </div>
-            <div>
-              <label for="bride-name">Имя невесты</label>
-              <input id="bride-name" name="brideName" type="text" required placeholder="Анна" value="${profile.brideName ? profile.brideName : ""}">
-            </div>
-            <div class="welcome-actions">
-              <button type="submit">Начать тест</button>
-              ${profile.weddingId ? `<button type="button" class="secondary" id="goto-dashboard">Перейти к рабочему столу</button>` : ""}
-            </div>
-          </form>
+          <div class="welcome-steps">
+            <h2>Как это работает</h2>
+            <ul class="steps-list">
+              <li>
+                <span class="step-icon" aria-hidden="true">📝</span>
+                <div>
+                  <h3>Ответьте на 11 вопросов</h3>
+                  <p>Расскажите немного о вашей паре и ожиданиях от праздника.</p>
+                </div>
+              </li>
+              <li>
+                <span class="step-icon" aria-hidden="true">📊</span>
+                <div>
+                  <h3>Получите персональный дашборд</h3>
+                  <p>Сводка ключевых параметров и дальнейшие шаги всегда под рукой.</p>
+                </div>
+              </li>
+              <li>
+                <span class="step-icon" aria-hidden="true">💞</span>
+                <div>
+                  <h3>Добавьте подрядчиков в избранное</h3>
+                  <p>Сохраняйте понравившихся специалистов и возвращайтесь к ним в любое время.</p>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <p class="welcome-footer">By Lex</p>
         </section>
       `;
-      const form = document.getElementById("welcome-form");
-      const groomInput = document.getElementById("groom-name");
-      const brideInput = document.getElementById("bride-name");
-      form.addEventListener("submit", (event) => {
-        event.preventDefault();
-        const groomName = groomInput.value.trim();
-        const brideName = brideInput.value.trim();
-        if (!groomName) {
-          groomInput.setCustomValidity("Введите имя жениха");
-          groomInput.reportValidity();
-          groomInput.setCustomValidity("");
-          groomInput.focus();
-          return;
-        }
-        if (!brideName) {
-          brideInput.setCustomValidity("Введите имя невесты");
-          brideInput.reportValidity();
-          brideInput.setCustomValidity("");
-          brideInput.focus();
-          return;
-        }
-        const now = Date.now();
-        const currentYear = new Date().getFullYear();
-        const profileData = this.state.profile || {
-          schemaVersion: 1,
-          weddingId: Date.now().toString(),
-          vibe: [],
-          style: "",
-          venueBooked: false,
-          city: "",
-          year: currentYear,
-          month: new Date().getMonth() + 1,
-          budgetRange: "",
-          guests: 50,
-          createdAt: now
-        };
-        const profile = {
-          ...profileData,
-          groomName,
-          brideName,
-          updatedAt: now
-        };
-        this.saveProfile(profile);
-        this.state.profile = profile;
+      const startButton = document.getElementById("start-quiz");
+      startButton.addEventListener("click", () => {
+        this.ensureProfile();
+        this.state.currentStep = 0;
         location.hash = "#/quiz";
       });
-      const dashboardBtn = document.getElementById("goto-dashboard");
-      if (dashboardBtn) {
-        dashboardBtn.addEventListener("click", () => {
-          location.hash = "#/dashboard";
-        });
-      }
     },
     renderQuiz() {
-      if (!this.state.profile) {
-        location.replace("#/welcome");
-        return;
-      }
+      this.ensureProfile();
       this.appEl.innerHTML = `
         <section class="card">
           <h1>Подбор профиля свадьбы</h1>
@@ -547,6 +517,26 @@
       setTimeout(() => {
         location.hash = "#/dashboard";
       }, 1200);
+    },
+    ensureProfile() {
+      if (this.state.profile) return;
+      const now = Date.now();
+      const currentYear = new Date().getFullYear();
+      const profile = {
+        schemaVersion: 1,
+        weddingId: now.toString(),
+        vibe: [],
+        style: "",
+        venueBooked: false,
+        city: "",
+        year: currentYear,
+        month: new Date().getMonth() + 1,
+        budgetRange: "",
+        guests: 50,
+        createdAt: now,
+        updatedAt: now
+      };
+      this.saveProfile(profile);
     },
     renderDashboard() {
       const profile = this.state.profile;

--- a/app.js
+++ b/app.js
@@ -109,7 +109,7 @@
               <p class="welcome-note">Это бесплатно. Прогресс сохраняется.</p>
             </div>
             <div class="welcome-hero" role="presentation">
-              <img src="https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=1200&q=80" alt="Счастливая пара на фоне горного озера" loading="lazy" decoding="async">
+              <img src="https://images.unsplash.com/photo-1591604466107-ec97de577aff?q=80&w=2071&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="Счастливая пара на фоне горного озера" loading="lazy" decoding="async">
             </div>
           </div>
           <div class="welcome-steps">
@@ -138,7 +138,6 @@
               </li>
             </ul>
           </div>
-          <p class="welcome-footer">By Lex</p>
         </section>
       `;
       const startButton = document.getElementById("start-quiz");

--- a/styles.css
+++ b/styles.css
@@ -46,6 +46,105 @@ p {
   box-shadow: 0 10px 25px rgba(47, 42, 59, 0.08);
 }
 
+.welcome {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.welcome-layout {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: center;
+}
+
+.welcome-content h1 {
+  font-size: clamp(2rem, 2.6vw + 1.2rem, 3rem);
+}
+
+.welcome-subtitle {
+  font-size: 1.05rem;
+  color: var(--muted);
+  margin-bottom: 1.5rem;
+}
+
+.welcome-content button {
+  width: fit-content;
+  min-width: 200px;
+}
+
+.welcome-note {
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.welcome-hero {
+  position: relative;
+  border-radius: 24px;
+  overflow: hidden;
+  box-shadow: 0 18px 40px rgba(47, 42, 59, 0.18);
+}
+
+.welcome-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(47, 42, 59, 0.1), rgba(47, 42, 59, 0.25));
+  pointer-events: none;
+}
+
+.welcome-hero img {
+  width: 100%;
+  display: block;
+  object-fit: cover;
+  min-height: 240px;
+}
+
+.welcome-steps h2 {
+  font-size: 1.5rem;
+}
+
+.steps-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.steps-list li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: start;
+}
+
+.steps-list h3 {
+  margin: 0 0 0.5rem;
+}
+
+.steps-list p {
+  margin: 0;
+}
+
+.step-icon {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  background: rgba(224, 122, 139, 0.14);
+  display: grid;
+  place-items: center;
+  font-size: 1.5rem;
+}
+
+.welcome-footer {
+  margin: 0;
+  font-size: 0.85rem;
+  text-align: right;
+  color: rgba(47, 42, 59, 0.5);
+}
+
 form {
   display: grid;
   gap: 1.5rem;
@@ -293,6 +392,14 @@ button.secondary:hover {
 
   .card {
     padding: 1.5rem;
+  }
+
+  .welcome-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .welcome-content button {
+    width: 100%;
   }
 
   .dashboard-grid {

--- a/styles.css
+++ b/styles.css
@@ -138,13 +138,6 @@ p {
   font-size: 1.5rem;
 }
 
-.welcome-footer {
-  margin: 0;
-  font-size: 0.85rem;
-  text-align: right;
-  color: rgba(47, 42, 59, 0.5);
-}
-
 form {
   display: grid;
   gap: 1.5rem;


### PR DESCRIPTION
## Summary
- replace the form-based welcome screen with a hero intro that highlights the service, the onboarding steps, and a CTA
- wire the CTA to create an initial profile and jump straight into the quiz while keeping existing quiz flow intact
- add styling and assets for the new welcome layout while preserving current theme and responsiveness
- update the welcome hero to load photography from a remote source so no binary asset is required in the repo

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cb0d44489c83249cdf88f6410bbcf3