### PR TITLE
Redesign welcome hero and add module grid

### DIFF
--- a/app.js
+++ b/app.js
@@ -99,52 +99,40 @@
       }
     },
     renderWelcome() {
+      const cards = MODULE_CARDS.map((card) => `
+        <article class="dashboard-card ${card.size === "lg" ? "lg" : ""}" tabindex="0" data-card="${card.id}">
+          <h3>${card.title}</h3>
+          <p>Покажем лучших специалистов, как только всё будет готово.</p>
+        </article>
+      `).join("");
       this.appEl.innerHTML = `
         <section class="card welcome">
           <div class="welcome-layout">
             <div class="welcome-content">
-              <h1>Планирование свадьбы без стресса</h1>
-              <p class="welcome-subtitle">Подберём подрядчиков, поможем с бюджетом и сроками — всё в одном месте. Пройдите короткий тест, и мы настроим рекомендации под вашу пару.</p>
-              <button type="button" id="start-quiz">Начать тест</button>
-              <p class="welcome-note">Это бесплатно. Прогресс сохраняется.</p>
+              <h1>Тёплое начало для вашей свадьбы</h1>
+              <p>Мы соберём проверенных подрядчиков и идеи, которые отражают настроение вашей пары.</p>
+              <p>Расскажите о мечтах и планах — и мы превратим их в персональный план праздника.</p>
+              <a class="welcome-link" href="#/quiz">Пройти короткий тест →</a>
             </div>
-            <div class="welcome-hero" role="presentation">
-              <img src="https://images.unsplash.com/photo-1591604466107-ec97de577aff?q=80&w=2071&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="Счастливая пара на фоне горного озера" loading="lazy" decoding="async">
-            </div>
-          </div>
-          <div class="welcome-steps">
-            <h2>Как это работает</h2>
-            <ul class="steps-list">
-              <li>
-                <span class="step-icon" aria-hidden="true">📝</span>
-                <div>
-                  <h3>Ответьте на 11 вопросов</h3>
-                  <p>Расскажите немного о вашей паре и ожиданиях от праздника.</p>
-                </div>
-              </li>
-              <li>
-                <span class="step-icon" aria-hidden="true">📊</span>
-                <div>
-                  <h3>Получите персональный дашборд</h3>
-                  <p>Сводка ключевых параметров и дальнейшие шаги всегда под рукой.</p>
-                </div>
-              </li>
-              <li>
-                <span class="step-icon" aria-hidden="true">💞</span>
-                <div>
-                  <h3>Добавьте подрядчиков в избранное</h3>
-                  <p>Сохраняйте понравившихся специалистов и возвращайтесь к ним в любое время.</p>
-                </div>
-              </li>
-            </ul>
+            <figure class="welcome-hero" role="presentation">
+              <img src="https://images.unsplash.com/photo-1478059425650-ca13d6d422f4?q=80&w=1989&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="Влюблённая пара, улыбающаяся и обнимающаяся на закате" loading="lazy" decoding="async">
+            </figure>
           </div>
         </section>
+        <section class="card welcome-modules">
+          <h2>Главные разделы платформы</h2>
+          <p class="welcome-modules__subtitle">Мы готовим подборки специалистов под ваш стиль, город и бюджет. Всё появится в этих разделах.</p>
+          <div class="dashboard-grid welcome-grid">${cards}</div>
+        </section>
       `;
-      const startButton = document.getElementById("start-quiz");
-      startButton.addEventListener("click", () => {
-        this.ensureProfile();
-        this.state.currentStep = 0;
-        location.hash = "#/quiz";
+      this.appEl.querySelectorAll(".dashboard-card").forEach((card) => {
+        card.addEventListener("click", () => this.openModal(card));
+        card.addEventListener("keydown", (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            this.openModal(card);
+          }
+        });
       });
     },
     renderQuiz() {

--- a/styles.css
+++ b/styles.css
@@ -62,21 +62,33 @@ p {
   font-size: clamp(2rem, 2.6vw + 1.2rem, 3rem);
 }
 
-.welcome-subtitle {
+.welcome-content p {
   font-size: 1.05rem;
-  color: var(--muted);
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.25rem;
 }
 
-.welcome-content button {
-  width: fit-content;
-  min-width: 200px;
+.welcome-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: var(--accent-dark);
+  text-decoration: none;
 }
 
-.welcome-note {
-  margin-top: 0.75rem;
-  font-size: 0.9rem;
-  color: var(--muted);
+.welcome-link::after {
+  content: "";
+  width: 0.55rem;
+  height: 0.55rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(-45deg);
+  margin-top: 1px;
+}
+
+.welcome-link:hover,
+.welcome-link:focus {
+  color: var(--accent);
 }
 
 .welcome-hero {
@@ -101,41 +113,18 @@ p {
   min-height: 240px;
 }
 
-.welcome-steps h2 {
-  font-size: 1.5rem;
-}
-
-.steps-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.welcome-modules {
   display: grid;
   gap: 1.5rem;
 }
 
-.steps-list li {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 1rem;
-  align-items: start;
-}
-
-.steps-list h3 {
-  margin: 0 0 0.5rem;
-}
-
-.steps-list p {
+.welcome-modules__subtitle {
   margin: 0;
+  font-size: 1rem;
 }
 
-.step-icon {
-  width: 3rem;
-  height: 3rem;
-  border-radius: 50%;
-  background: rgba(224, 122, 139, 0.14);
-  display: grid;
-  place-items: center;
-  font-size: 1.5rem;
+.welcome-grid .dashboard-card {
+  cursor: pointer;
 }
 
 form {


### PR DESCRIPTION
## Summary
- redesign the welcome view into a warm hero with new copy, imagery, and link to the quiz
- add the main module card grid below the hero to preview key sections
- update styles for the refreshed hero and supporting elements

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfbf194e148324b3849bcc093e4595