### PR TITLE
feat: enhance budget module interactions

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -481,61 +481,161 @@ button.secondary:hover {
 
 .budget-summary {
   display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
+  justify-content: center;
+  margin-bottom: 1.5rem;
 }
 
-.budget-summary__label {
-  font-weight: 600;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  font-size: 0.75rem;
+.budget-total {
+  display: grid;
+  gap: 0.5rem;
+  justify-items: center;
 }
 
-.budget-summary__value {
-  font-size: clamp(1.5rem, 1.5vw + 1rem, 2.25rem);
+.budget-total__chart {
+  --chart-bg: radial-gradient(circle at center, rgba(224, 122, 139, 0.3) 0%, rgba(224, 122, 139, 0.12) 65%, rgba(224, 122, 139, 0.18) 100%);
+  position: relative;
+  width: clamp(140px, 10vw + 110px, 200px);
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background-image: var(--chart-bg);
+  transition: background-image 0.4s ease;
+}
+
+.budget-total__chart::after {
+  content: "";
+  position: absolute;
+  inset: 18%;
+  background: #fff;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px rgba(224, 122, 139, 0.12);
+}
+
+.budget-total__value {
+  position: relative;
+  font-size: clamp(1.35rem, 1.4vw + 1rem, 2.2rem);
   font-weight: 700;
   color: var(--accent-dark);
 }
 
-.budget-visual {
-  display: grid;
-  gap: 1rem;
+.budget-total__caption {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
 }
 
-.budget-visual__item {
+.budget-entries {
   display: grid;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
-.budget-visual__info {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 1rem;
+.budget-entry {
+  display: grid;
+  grid-template-columns: auto minmax(160px, 1fr) minmax(140px, auto) auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(224, 122, 139, 0.06);
+}
+
+.budget-entry__color {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--entry-color, var(--accent));
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.9);
+}
+
+.budget-entry__title,
+.budget-entry__amount-input {
+  border: 1px solid rgba(224, 122, 139, 0.32);
+  border-radius: 0.75rem;
+  padding: 0.55rem 0.75rem;
   font-weight: 600;
   color: var(--txt);
+  background: #fff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.budget-visual__amount {
+.budget-entry__title:focus,
+.budget-entry__amount-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(224, 122, 139, 0.18);
+}
+
+.budget-entry__amount {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.budget-entry__amount-input {
+  width: 100%;
+  padding-right: 2rem;
+}
+
+.budget-entry__currency {
+  position: absolute;
+  right: 0.75rem;
   color: var(--muted);
   font-weight: 600;
+  pointer-events: none;
 }
 
-.budget-visual__track {
-  height: 10px;
-  border-radius: 999px;
-  background: rgba(224, 122, 139, 0.12);
-  overflow: hidden;
+.budget-entry__delete {
+  position: relative;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(224, 122, 139, 0.14);
+  color: var(--accent);
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.budget-visual__bar {
-  height: 100%;
-  width: 0;
+.budget-entry__delete::before,
+.budget-entry__delete::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  background: currentColor;
+  top: 50%;
+  left: 50%;
   border-radius: 999px;
-  background: linear-gradient(90deg, var(--accent), var(--success));
-  transition: width 0.6s ease;
+}
+
+.budget-entry__delete::before {
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.budget-entry__delete::after {
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
+.budget-entry__delete:hover {
+  background: rgba(224, 122, 139, 0.2);
+  transform: scale(1.05);
+}
+
+.budget-entry__delete:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(224, 122, 139, 0.25);
+}
+
+.budget-entries__empty {
+  text-align: center;
+  color: var(--muted);
+  padding: 1rem;
+  background: rgba(224, 122, 139, 0.05);
+  border-radius: 0.75rem;
+  font-weight: 500;
 }
 
 .budget-form {
@@ -679,6 +779,20 @@ button.secondary:hover {
 
   .budget-form__fields {
     flex-direction: column;
+  }
+
+  .budget-entry {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.5rem;
+  }
+
+  .budget-entry__amount,
+  .budget-entry__title {
+    width: 100%;
+  }
+
+  .budget-entry__delete {
+    justify-self: end;
   }
 
   .actions {


### PR DESCRIPTION
## Summary
- replace the budget total headline with a circular chart that highlights the full amount
- add inline editing and deletion controls for budget items together with refreshed styling

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d0163f48548324abbd3816acd20103