### PR TITLE
Refine budget chart and inline controls

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -481,22 +481,49 @@ button.secondary:hover {
 
 .budget-summary {
   display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
+  justify-content: center;
+  padding: 0.75rem 0 1.5rem;
 }
 
-.budget-summary__label {
-  font-weight: 600;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  font-size: 0.75rem;
+.budget-summary__chart {
+  position: relative;
+  width: min(180px, 38vw);
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  background: var(
+    --budget-chart-bg,
+    conic-gradient(from -90deg, rgba(224, 122, 139, 0.25) 0deg 360deg)
+  );
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 18px 36px rgba(224, 122, 139, 0.18);
+}
+
+.budget-summary__chart::after {
+  content: "";
+  position: absolute;
+  inset: 22%;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: inset 0 0 0 1px rgba(224, 122, 139, 0.12);
+}
+
+.budget-summary__total {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  text-align: center;
 }
 
 .budget-summary__value {
-  font-size: clamp(1.5rem, 1.5vw + 1rem, 2.25rem);
+  font-size: clamp(1.6rem, 1.5vw + 1.1rem, 2.5rem);
   font-weight: 700;
   color: var(--accent-dark);
+  letter-spacing: -0.01em;
 }
 
 .budget-visual {
@@ -511,16 +538,30 @@ button.secondary:hover {
 
 .budget-visual__info {
   display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 1rem;
+  align-items: center;
+  gap: 0.75rem;
   font-weight: 600;
   color: var(--txt);
 }
 
+.budget-visual__title {
+  flex: 1 1 auto;
+}
+
+
 .budget-visual__amount {
   color: var(--muted);
   font-weight: 600;
+  margin-left: auto;
+}
+
+.budget-visual__dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background: var(--dot-color, var(--accent));
+  box-shadow: 0 0 0 4px rgba(224, 122, 139, 0.12);
+  flex: 0 0 auto;
 }
 
 .budget-visual__track {
@@ -534,8 +575,74 @@ button.secondary:hover {
   height: 100%;
   width: 0;
   border-radius: 999px;
-  background: linear-gradient(90deg, var(--accent), var(--success));
+  background: var(--bar-color, linear-gradient(90deg, var(--accent), var(--success)));
   transition: width 0.6s ease;
+}
+
+.budget-visual__icon {
+  border-radius: 50%;
+  width: 2rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(224, 122, 139, 0.14);
+  color: var(--accent-dark);
+  font-size: 1rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.budget-visual__icon:hover,
+.budget-visual__icon:focus-visible {
+  background: rgba(224, 122, 139, 0.24);
+  transform: translateY(-1px);
+}
+
+.budget-visual__icon--danger {
+  background: rgba(192, 69, 95, 0.16);
+  color: #c0455f;
+}
+
+.budget-visual__icon--danger:hover,
+.budget-visual__icon--danger:focus-visible {
+  background: rgba(192, 69, 95, 0.28);
+}
+
+.budget-visual__item--editing {
+  background: rgba(224, 122, 139, 0.08);
+  border-radius: 18px;
+  padding: 0.75rem;
+}
+
+.budget-visual__edit {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.budget-visual__edit-fields {
+  display: grid;
+  grid-template-columns: auto 1fr minmax(130px, 160px);
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.budget-visual__field input {
+  width: 100%;
+}
+
+.budget-visual__edit-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.budget-empty {
+  padding: 1.25rem;
+  border-radius: 16px;
+  background: rgba(224, 122, 139, 0.08);
+  color: var(--muted);
+  text-align: center;
+  font-weight: 600;
 }
 
 .budget-form {
@@ -667,6 +774,33 @@ button.secondary:hover {
       "tools"
       "checklist"
       "budget";
+  }
+
+  .budget-summary__chart {
+    width: min(160px, 60vw);
+    box-shadow: 0 12px 26px rgba(224, 122, 139, 0.16);
+  }
+
+  .budget-visual__edit-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .budget-visual__dot {
+    justify-self: flex-start;
+  }
+
+  .budget-visual__info {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .budget-visual__amount {
+    margin-right: 0.25rem;
+  }
+
+  .budget-visual__icon {
+    width: 2.25rem;
+    height: 2.25rem;
   }
 
   .checklist-form {


### PR DESCRIPTION
## Summary
- shrink the budget donut and center the total inside the ring
- swap textual budget actions for inline emoji icons beside each amount
- tweak responsive layout to keep compact entry rows on small screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0163f48548324abbd3816acd20103