### PR TITLE
Enhance checklist module interactions

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -389,7 +389,43 @@ button.secondary:hover {
 }
 
 .module-header h2 {
-  margin-bottom: 0.5rem;
+  margin: 0;
+}
+
+.module-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.module-icon-button {
+  background: rgba(224, 122, 139, 0.14);
+  color: var(--accent-dark);
+  border: none;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease;
+}
+
+.module-icon-button:hover {
+  background: rgba(224, 122, 139, 0.24);
+  color: var(--accent);
+}
+
+.module-icon-button:active {
+  transform: scale(0.95);
+}
+
+.module-icon-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .module-header p {
@@ -402,23 +438,26 @@ button.secondary:hover {
   padding: 0;
   margin: 0;
   display: grid;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .checklist-item {
   display: flex;
   gap: 0.75rem;
-  align-items: flex-start;
+  align-items: center;
+  justify-content: space-between;
   background: rgba(224, 122, 139, 0.08);
   border-radius: 14px;
-  padding: 0.75rem 1rem;
+  padding: 0.85rem 1rem;
   border: 1px solid rgba(224, 122, 139, 0.15);
+  position: relative;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
 }
 
 .checklist-item input[type="checkbox"] {
   width: 1.1rem;
   height: 1.1rem;
-  margin-top: 0.15rem;
+  margin-top: 0;
   accent-color: var(--accent);
 }
 
@@ -427,9 +466,99 @@ button.secondary:hover {
   color: var(--txt);
 }
 
+.checklist-item__main {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex: 1 1 auto;
+}
+
+.checklist-item__actions {
+  display: flex;
+  gap: 0.35rem;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-4px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.checklist-item__action {
+  background: transparent;
+  border-radius: 999px;
+  border: 1px solid rgba(224, 122, 139, 0.35);
+  color: var(--accent-dark);
+  padding: 0.3rem 0.55rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.checklist-item__action:hover {
+  background: rgba(224, 122, 139, 0.18);
+  color: var(--accent);
+  border-color: rgba(224, 122, 139, 0.55);
+}
+
+.checklist-item__action:active {
+  transform: translateY(1px);
+}
+
+.checklist-item__action--danger {
+  color: #b84052;
+  border-color: rgba(184, 64, 82, 0.35);
+}
+
+.checklist-item__action--danger:hover {
+  background: rgba(184, 64, 82, 0.18);
+  color: #b84052;
+  border-color: rgba(184, 64, 82, 0.55);
+}
+
+.checklist-item:hover {
+  border-color: rgba(224, 122, 139, 0.35);
+  box-shadow: 0 10px 25px rgba(224, 122, 139, 0.16);
+  transform: translateY(-2px);
+}
+
+.checklist-item:hover .checklist-item__actions,
+.checklist-item:focus-within .checklist-item__actions {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
 .checklist-item input[type="checkbox"]:checked + label {
   text-decoration: line-through;
   color: var(--muted);
+}
+
+.checklist-item--editing {
+  background: #fff;
+  border: 1px solid rgba(224, 122, 139, 0.45);
+  box-shadow: 0 18px 36px rgba(224, 122, 139, 0.25);
+}
+
+.checklist-item__edit {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.checklist-item__edit input[type="text"] {
+  border-radius: 12px;
+  border: 1px solid rgba(224, 122, 139, 0.35);
+  padding: 0.85rem 1rem;
+  font-weight: 600;
+  color: var(--txt);
+}
+
+.checklist-item__edit-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .checklist-form {
@@ -440,6 +569,71 @@ button.secondary:hover {
 
 .checklist-form input {
   flex: 1 1 auto;
+}
+
+.checklist-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(47, 42, 59, 0.45);
+  backdrop-filter: blur(3px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 980;
+}
+
+.checklist-overlay.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+body.checklist-expanded {
+  overflow: hidden;
+}
+
+.dashboard-module.checklist {
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.dashboard-module.checklist.dashboard-module--expanded {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(720px, 90vw);
+  height: min(80vh, 640px);
+  max-height: min(86vh, 720px);
+  overflow: hidden;
+  padding: 2.25rem;
+  z-index: 990;
+  box-shadow: 0 40px 90px rgba(47, 42, 59, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.dashboard-module.checklist.dashboard-module--expanded .checklist-items {
+  overflow-y: auto;
+  padding-right: 0.25rem;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.dashboard-module.checklist.dashboard-module--expanded .checklist-item {
+  transform: none;
+}
+
+.dashboard-module.checklist.dashboard-module--expanded .checklist-form {
+  margin-top: 0.5rem;
+  flex: 0 0 auto;
+}
+
+@media (hover: none) {
+  .checklist-item__actions {
+    opacity: 1;
+    pointer-events: auto;
+    transform: none;
+  }
 }
 
 .tools-grid {


### PR DESCRIPTION
## Summary
- Add checklist expansion state with overlay, focus handling, and escape shortcuts for a modal-like experience.
- Provide inline edit and delete actions for checklist tasks with supporting persistence updates and sanitization.
- Refresh checklist styling to surface contextual action buttons and polished expanded presentation.

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d187cc8810832487097f21b766b3c3