### PR TITLE
Add checklist folders with drag-and-drop organization

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -364,6 +364,14 @@ button.secondary:hover {
   grid-template-columns: minmax(260px, 320px) minmax(360px, 1fr) minmax(260px, 320px);
   grid-template-areas: "checklist tools budget";
   align-items: start;
+  position: relative;
+}
+
+.dashboard-modules--checklist-expanded .dashboard-module:not(.checklist) {
+  filter: blur(1px);
+  opacity: 0.45;
+  pointer-events: none;
+  transition: filter 0.3s ease, opacity 0.3s ease;
 }
 
 .dashboard-module {
@@ -388,13 +396,123 @@ button.secondary:hover {
   grid-area: budget;
 }
 
+.dashboard-module.checklist {
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  cursor: default;
+  will-change: transform;
+}
+
+.dashboard-module.checklist:not(.checklist--expanded):hover {
+  box-shadow: 0 16px 34px rgba(47, 42, 59, 0.16);
+}
+
+.dashboard-module.checklist--expanded {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(1);
+  width: min(720px, 90vw);
+  height: min(80vh, 680px);
+  max-height: 80vh;
+  z-index: 90;
+  box-shadow: 0 30px 60px rgba(36, 32, 51, 0.28);
+  padding: 2rem;
+  gap: 1.75rem;
+  overflow: hidden;
+  animation: checklist-pop 0.3s ease;
+}
+
+.dashboard-module.checklist--expanded .checklist-content {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding-right: 0.35rem;
+  margin-right: -0.35rem;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(224, 122, 139, 0.4) transparent;
+}
+
+.dashboard-module.checklist--expanded .checklist-content::-webkit-scrollbar {
+  width: 6px;
+}
+
+.dashboard-module.checklist--expanded .checklist-content::-webkit-scrollbar-thumb {
+  background: rgba(224, 122, 139, 0.35);
+  border-radius: 999px;
+}
+
+.dashboard-module.checklist--expanded .checklist-form {
+  margin-top: auto;
+}
+
+.dashboard-module.checklist--expanded .checklist-form input {
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.checklist-overlay {
+  position: fixed;
+  inset: 0;
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: rgba(36, 32, 51, 0.35);
+  backdrop-filter: blur(3px);
+  cursor: pointer;
+  z-index: 80;
+  opacity: 1;
+  animation: checklist-overlay-fade 0.3s ease;
+}
+
+body.checklist-expanded {
+  overflow: hidden;
+}
+
+.module-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
 .module-header h2 {
-  margin-bottom: 0.5rem;
+  margin: 0;
 }
 
 .module-header p {
   margin: 0;
   color: var(--muted);
+  flex-basis: 100%;
+}
+
+.module-header__actions {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.module-header__icon-button {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: none;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(224, 122, 139, 0.18);
+  color: var(--accent-dark);
+  font-size: 1.05rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.module-header__icon-button:hover,
+.module-header__icon-button:focus-visible {
+  background: rgba(224, 122, 139, 0.26);
+  transform: translateY(-1px);
+}
+
+.module-header__icon-button span {
+  pointer-events: none;
 }
 
 .checklist-items {
@@ -405,31 +523,278 @@ button.secondary:hover {
   gap: 0.75rem;
 }
 
+.checklist-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.checklist-items--root {
+  padding: 0.35rem 0.5rem;
+  border-radius: 16px;
+  border: 1px dashed rgba(224, 122, 139, 0.14);
+  background: rgba(255, 255, 255, 0.45);
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.checklist-folders {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.checklist-folder {
+  border-radius: 16px;
+  border: 1px solid rgba(224, 122, 139, 0.18);
+  background: rgba(224, 122, 139, 0.06);
+  padding: 0.75rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.checklist-folder:hover {
+  border-color: rgba(224, 122, 139, 0.28);
+  box-shadow: 0 16px 34px rgba(224, 122, 139, 0.18);
+}
+
+.checklist-folder__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 12px;
+  border: 1px dashed transparent;
+  padding: 0.35rem 0.5rem;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.checklist-folder__header:hover {
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.checklist-folder__toggle {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(224, 122, 139, 0.18);
+  color: var(--accent-dark);
+  font-size: 0.85rem;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.checklist-folder__toggle:hover,
+.checklist-folder__toggle:focus-visible {
+  background: rgba(224, 122, 139, 0.26);
+  transform: translateY(-1px);
+}
+
+.checklist-folder__glyph {
+  font-size: 1.1rem;
+  opacity: 0.8;
+}
+
+.checklist-folder__name {
+  font-weight: 600;
+  color: var(--txt);
+  flex: 1 1 auto;
+}
+
+.checklist-folder__count {
+  min-width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  background: rgba(224, 122, 139, 0.18);
+  color: var(--accent-dark);
+  font-size: 0.85rem;
+  display: grid;
+  place-items: center;
+}
+
+.checklist-folder__items {
+  list-style: none;
+  padding: 0 0 0 2.5rem;
+  margin: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.checklist-folder__items[hidden] {
+  display: none;
+}
+
+.checklist-folder-form {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: rgba(224, 122, 139, 0.1);
+  border: 1px solid rgba(224, 122, 139, 0.24);
+  border-radius: 16px;
+  box-shadow: 0 18px 34px rgba(224, 122, 139, 0.16);
+}
+
+.checklist-folder-form input {
+  width: 100%;
+}
+
+.checklist-folder-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.checklist-empty {
+  color: var(--muted);
+  font-size: 0.95rem;
+  padding: 0.15rem 0;
+}
+
+.checklist-empty--folders {
+  text-align: center;
+  padding: 0.5rem 0;
+}
+
+.checklist-drop-target--active {
+  border-color: rgba(224, 122, 139, 0.52) !important;
+  background: rgba(224, 122, 139, 0.12) !important;
+  box-shadow: 0 16px 34px rgba(224, 122, 139, 0.18);
+}
+
+.checklist-item--dragging {
+  opacity: 0.65;
+  transform: scale(0.98);
+  box-shadow: 0 18px 36px rgba(224, 122, 139, 0.22);
+}
+
 .checklist-item {
   display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 0.75rem;
-  align-items: flex-start;
   background: rgba(224, 122, 139, 0.08);
   border-radius: 14px;
-  padding: 0.75rem 1rem;
-  border: 1px solid rgba(224, 122, 139, 0.15);
+  padding: 0.85rem 1.1rem;
+  border: 1px solid rgba(224, 122, 139, 0.18);
+  position: relative;
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.checklist-item[draggable="true"] {
+  cursor: grab;
+}
+
+.checklist-item--dragging {
+  cursor: grabbing;
+}
+
+.checklist-item:hover,
+.checklist-item:focus-within {
+  background: rgba(224, 122, 139, 0.14);
+  box-shadow: 0 14px 30px rgba(224, 122, 139, 0.18);
+  transform: translateY(-1px);
+}
+
+.checklist-item__main {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  flex: 1 1 auto;
 }
 
 .checklist-item input[type="checkbox"] {
-  width: 1.1rem;
-  height: 1.1rem;
+  width: 1.15rem;
+  height: 1.15rem;
   margin-top: 0.15rem;
   accent-color: var(--accent);
+  flex: 0 0 auto;
 }
 
 .checklist-item label {
   font-weight: 600;
   color: var(--txt);
+  flex: 1 1 auto;
+  line-height: 1.4;
 }
 
 .checklist-item input[type="checkbox"]:checked + label {
   text-decoration: line-through;
   color: var(--muted);
+}
+
+.checklist-item__actions {
+  display: flex;
+  gap: 0.35rem;
+  margin-left: 0.35rem;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-6px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.checklist-item:hover .checklist-item__actions,
+.checklist-item:focus-within .checklist-item__actions {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.checklist-item__action {
+  width: 1.65rem;
+  height: 1.65rem;
+  border-radius: 999px;
+  border: none;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(224, 122, 139, 0.16);
+  color: var(--accent-dark);
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.checklist-item__action:hover,
+.checklist-item__action:focus-visible {
+  background: rgba(224, 122, 139, 0.24);
+}
+
+.checklist-item__action--danger {
+  background: rgba(192, 69, 95, 0.16);
+  color: #c0455f;
+}
+
+.checklist-item__action--danger:hover,
+.checklist-item__action--danger:focus-visible {
+  background: rgba(192, 69, 95, 0.24);
+}
+
+.checklist-item--editing {
+  background: rgba(224, 122, 139, 0.12);
+  border-color: rgba(224, 122, 139, 0.32);
+  box-shadow: 0 16px 34px rgba(224, 122, 139, 0.22);
+}
+
+.checklist-item__edit {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.checklist-item__edit input {
+  width: 100%;
+}
+
+.checklist-item__edit-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
 }
 
 .checklist-form {
@@ -695,6 +1060,26 @@ button.secondary:hover {
   font-size: 0.9rem;
 }
 
+@keyframes checklist-pop {
+  from {
+    transform: translate(-50%, -50%) scale(0.92);
+    opacity: 0;
+  }
+  to {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes checklist-overlay-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 #modal-overlay {
   position: fixed;
   inset: 0;
@@ -754,6 +1139,12 @@ button.secondary:hover {
       "checklist tools"
       "budget budget";
   }
+
+  .dashboard-module.checklist--expanded {
+    width: min(640px, 92vw);
+    height: min(82vh, 640px);
+    padding: 1.75rem;
+  }
 }
 
 @media (max-width: 600px) {
@@ -785,6 +1176,63 @@ button.secondary:hover {
       "tools"
       "checklist"
       "budget";
+  }
+
+  .dashboard-module.checklist--expanded {
+    width: 92vw;
+    height: min(85vh, 540px);
+    padding: 1.35rem;
+  }
+
+  .checklist-items--root {
+    padding: 0.25rem 0.35rem;
+  }
+
+  .checklist-folder {
+    padding: 0.6rem 0.75rem;
+  }
+
+  .checklist-folder__items {
+    padding-left: 1.75rem;
+  }
+
+  .checklist-folder__toggle {
+    width: 1.6rem;
+    height: 1.6rem;
+  }
+
+  .checklist-folder__count {
+    min-width: 1.55rem;
+    height: 1.55rem;
+    font-size: 0.8rem;
+  }
+
+  .checklist-folder-form {
+    padding: 0.85rem 1rem;
+  }
+
+  .checklist-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.65rem;
+  }
+
+  .checklist-item__main {
+    width: 100%;
+  }
+
+  .checklist-item__actions {
+    opacity: 1;
+    pointer-events: auto;
+    transform: none;
+    margin-left: 0;
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .checklist-item__action {
+    width: 1.55rem;
+    height: 1.55rem;
   }
 
   .budget-summary__chart {


### PR DESCRIPTION
## Summary
- add checklist folder metadata and sanitization so profiles persist group structure
- render folder creation UI, grouping, and drag-and-drop task reassignment in the checklist module
- refresh checklist styling to support folder cards, drop indicators, and responsive spacing

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d187cc8810832487097f21b766b3c3