### PR TITLE
Add favorites and phone reveal to marketplace

### DIFF
--- a/data.js
+++ b/data.js
@@ -103,3 +103,664 @@ const DEFAULT_BUDGET_ENTRIES = [
   { id: "budget-decor", title: "Декор и флористика", amount: 90000 },
   { id: "budget-photo", title: "Фото и видео", amount: 120000 }
 ];
+
+const MARKETPLACE_IMAGES = [
+  "https://images.unsplash.com/photo-1606800052052-a08af7148866?q=80&w=2940&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  "https://images.unsplash.com/photo-1472162072942-cd5147eb3902?q=80&w=2969&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  "https://images.unsplash.com/photo-1502635385003-ee1e6a1a742d?q=80&w=987&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  "https://images.unsplash.com/photo-1525772764200-be829a350797?q=80&w=987&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  "https://images.unsplash.com/photo-1485700281629-290c5a704409?q=80&w=2069&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+];
+
+const MARKETPLACE_CONTACT_PHONE = "+7 (999) 867 17 49";
+
+const CONTRACTOR_MARKETPLACE = [
+  {
+    id: "photographers",
+    title: "Фотографы",
+    contractors: [
+      {
+        id: "photo-vladimir",
+        name: "Фотограф Владимир",
+        tagline: "Теплые репортажи и нежные портреты в любом освещении.",
+        price: 24000,
+        rating: 4.9,
+        reviews: 1159,
+        image: MARKETPLACE_IMAGES[0],
+        location: "Москва · Подмосковье",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "photo-alina",
+        name: "Фотограф Алина",
+        tagline: "Помогу прожить день без позирования и сохранить эмоции семьи.",
+        price: 19000,
+        rating: 4.8,
+        reviews: 842,
+        image: MARKETPLACE_IMAGES[1],
+        location: "Санкт-Петербург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "photo-arseniy",
+        name: "Фотограф Арсений",
+        tagline: "Пленочная эстетика и авторский цвет для атмосферных историй.",
+        price: 27000,
+        rating: 4.7,
+        reviews: 623,
+        image: MARKETPLACE_IMAGES[2],
+        location: "Казань",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "photo-natalia",
+        name: "Фотограф Наталия",
+        tagline: "Светоносные портреты и съемка утра невесты без спешки.",
+        price: 22000,
+        rating: 4.9,
+        reviews: 982,
+        image: MARKETPLACE_IMAGES[3],
+        location: "Сочи",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "photo-ilya",
+        name: "Фотограф Илья",
+        tagline: "Документальная съемка и искренние кадры гостей в моменте.",
+        price: 17000,
+        rating: 4.5,
+        reviews: 311,
+        image: MARKETPLACE_IMAGES[4],
+        location: "Новосибирск",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "photo-darina",
+        name: "Фотограф Дарина",
+        tagline: "Большие свадьбы с ассистентом и экспресс-галерея за 48 часов.",
+        price: 26000,
+        rating: 4.8,
+        reviews: 753,
+        image: MARKETPLACE_IMAGES[0],
+        location: "Екатеринбург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      }
+    ]
+  },
+  {
+    id: "videographers",
+    title: "Видеографы",
+    contractors: [
+      {
+        id: "video-sergey",
+        name: "Видеограф Сергей",
+        tagline: "Cinemagraph-подача, звук с петель и премиальный монтаж.",
+        price: 26000,
+        rating: 4.9,
+        reviews: 534,
+        image: MARKETPLACE_IMAGES[1],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "video-anna",
+        name: "Видеограф Анна",
+        tagline: "Верну вас в эмоции дня за 5 минут экранного времени.",
+        price: 21000,
+        rating: 4.8,
+        reviews: 412,
+        image: MARKETPLACE_IMAGES[3],
+        location: "Сочи",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "video-timur",
+        name: "Видеограф Тимур",
+        tagline: "Динамичные ролики с дрона и стильные тизеры в соцсети.",
+        price: 23000,
+        rating: 4.6,
+        reviews: 287,
+        image: MARKETPLACE_IMAGES[0],
+        location: "Екатеринбург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "video-alexey",
+        name: "Видеограф Алексей",
+        tagline: "Storytelling клипы с live-озвучкой и архивом исходников.",
+        price: 25000,
+        rating: 4.8,
+        reviews: 478,
+        image: MARKETPLACE_IMAGES[4],
+        location: "Новосибирск",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "video-daria",
+        name: "Видеограф Дарья",
+        tagline: "Документальный монтаж и вертикальный тизер через 7 дней.",
+        price: 21000,
+        rating: 4.7,
+        reviews: 365,
+        image: MARKETPLACE_IMAGES[0],
+        location: "Краснодар",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "video-artyom",
+        name: "Видеограф Артём",
+        tagline: "Съемка на две камеры, aerial-графика и динамичный монтаж.",
+        price: 28000,
+        rating: 4.9,
+        reviews: 589,
+        image: MARKETPLACE_IMAGES[2],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      }
+    ]
+  },
+  {
+    id: "catering",
+    title: "Кейтеринг",
+    contractors: [
+      {
+        id: "catering-gastroparty",
+        name: "GastroParty",
+        tagline: "Авторские сет-меню с открытой кухней и live станциями.",
+        price: 30000,
+        rating: 4.8,
+        reviews: 657,
+        image: MARKETPLACE_IMAGES[4],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "catering-lavanda",
+        name: "Кейтеринг Лаванда",
+        tagline: "Средиземноморский стол с акцентом на локальные продукты.",
+        price: 22000,
+        rating: 4.7,
+        reviews: 489,
+        image: MARKETPLACE_IMAGES[2],
+        location: "Краснодар",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "catering-artfood",
+        name: "ArtFood",
+        tagline: "Фуршет + банкет, персональные дегустации и сладкий стол.",
+        price: 26000,
+        rating: 4.9,
+        reviews: 915,
+        image: MARKETPLACE_IMAGES[3],
+        location: "Санкт-Петербург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "catering-chefstable",
+        name: "Chef's Table",
+        tagline: "Авторский дегустационный сет и локальные фермерские продукты.",
+        price: 28000,
+        rating: 4.8,
+        reviews: 712,
+        image: MARKETPLACE_IMAGES[1],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "catering-berrybar",
+        name: "Berry Bar",
+        tagline: "Фуршет с live станциями и signature-коктейлями для гостей.",
+        price: 24000,
+        rating: 4.6,
+        reviews: 455,
+        image: MARKETPLACE_IMAGES[0],
+        location: "Сочи",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "catering-seasons",
+        name: "Seasons Catering",
+        tagline: "Банкет на природе, гриль-станции и десертный шатёр.",
+        price: 26000,
+        rating: 4.9,
+        reviews: 538,
+        image: MARKETPLACE_IMAGES[4],
+        location: "Подмосковье",
+        phone: MARKETPLACE_CONTACT_PHONE
+      }
+    ]
+  },
+  {
+    id: "florists",
+    title: "Флористы",
+    contractors: [
+      {
+        id: "florist-maria",
+        name: "Флорист Мария",
+        tagline: "Воздушные букеты и декор церемонии в пастельных тонах.",
+        price: 18000,
+        rating: 4.9,
+        reviews: 743,
+        image: MARKETPLACE_IMAGES[0],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "florist-botanika",
+        name: "Botanika",
+        tagline: "Минимализм, живой мох и акценты из редких сортов цветов.",
+        price: 15000,
+        rating: 4.7,
+        reviews: 381,
+        image: MARKETPLACE_IMAGES[4],
+        location: "Санкт-Петербург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "florist-les",
+        name: "Студия Лес",
+        tagline: "Ботанический стиль, подвесные инсталляции и арки любой сложности.",
+        price: 20000,
+        rating: 4.8,
+        reviews: 529,
+        image: MARKETPLACE_IMAGES[2],
+        location: "Калининград",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "florist-atelier",
+        name: "Ателье Fleur",
+        tagline: "Арт-инсталляции и выездной флорист на площадке до финала.",
+        price: 21000,
+        rating: 4.8,
+        reviews: 612,
+        image: MARKETPLACE_IMAGES[3],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "florist-ivory",
+        name: "Ivory Flowers",
+        tagline: "Нежные композиции с сухоцветами и букет-дублер в подарок.",
+        price: 16000,
+        rating: 4.6,
+        reviews: 354,
+        image: MARKETPLACE_IMAGES[1],
+        location: "Екатеринбург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "florist-rosarium",
+        name: "Rosarium",
+        tagline: "Пышные арки, лепестковые дорожки и персональные бутоньерки.",
+        price: 23000,
+        rating: 4.9,
+        reviews: 488,
+        image: MARKETPLACE_IMAGES[2],
+        location: "Санкт-Петербург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      }
+    ]
+  },
+  {
+    id: "car-rentals",
+    title: "Аренда машин",
+    contractors: [
+      {
+        id: "cars-santorini",
+        name: "Кабриолет \"Санторини\"",
+        tagline: "Ретро кабриолет 1968 года с водителем в стиле old money.",
+        price: 27000,
+        rating: 4.8,
+        reviews: 218,
+        image: MARKETPLACE_IMAGES[1],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "cars-luxride",
+        name: "LuxRide",
+        tagline: "Флот бизнес-класса, welcome-зона с шампанским в пути.",
+        price: 24000,
+        rating: 4.7,
+        reviews: 354,
+        image: MARKETPLACE_IMAGES[3],
+        location: "Сочи",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "cars-prestigecar",
+        name: "PrestigeCar",
+        tagline: "Mercedes S-class и minivan для гостей с белым декором.",
+        price: 30000,
+        rating: 5.0,
+        reviews: 487,
+        image: MARKETPLACE_IMAGES[4],
+        location: "Санкт-Петербург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "cars-auroracabrio",
+        name: "Aurora Cabrio",
+        tagline: "Белый ретро-кабриолет с шофёром и шампанским welcome.",
+        price: 28000,
+        rating: 4.8,
+        reviews: 265,
+        image: MARKETPLACE_IMAGES[2],
+        location: "Санкт-Петербург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "cars-skyline",
+        name: "Skyline Drive",
+        tagline: "Tesla Model X, дрон-съемка выезда и декор лентами.",
+        price: 29000,
+        rating: 4.7,
+        reviews: 341,
+        image: MARKETPLACE_IMAGES[0],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "cars-velvetdrive",
+        name: "Velvet Drive",
+        tagline: "Мини-флот для гостей и водитель в перчатках.",
+        price: 22000,
+        rating: 4.5,
+        reviews: 198,
+        image: MARKETPLACE_IMAGES[3],
+        location: "Казань",
+        phone: MARKETPLACE_CONTACT_PHONE
+      }
+    ]
+  },
+  {
+    id: "attire-studios",
+    title: "Студии платьев и костюмов",
+    contractors: [
+      {
+        id: "attire-aquarelle",
+        name: "Студия Aquarelle",
+        tagline: "Индивидуальные примерки и корректировка силуэта за сутки.",
+        price: 25000,
+        rating: 4.9,
+        reviews: 688,
+        image: MARKETPLACE_IMAGES[0],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "attire-gentlemen",
+        name: "Gentlemen",
+        tagline: "Костюмы-трансформеры и аксессуары под цвет букета невесты.",
+        price: 17000,
+        rating: 4.6,
+        reviews: 241,
+        image: MARKETPLACE_IMAGES[2],
+        location: "Нижний Новгород",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "attire-whiteroom",
+        name: "Салон WhiteRoom",
+        tagline: "Кутюрные платья, выездной стилист и услуга steam-care.",
+        price: 28000,
+        rating: 4.8,
+        reviews: 915,
+        image: MARKETPLACE_IMAGES[1],
+        location: "Санкт-Петербург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "attire-atelierlace",
+        name: "Atelier Lace",
+        tagline: "Кастомный корсет, кружево и примерка на дому за 24 часа.",
+        price: 26000,
+        rating: 4.9,
+        reviews: 534,
+        image: MARKETPLACE_IMAGES[3],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "attire-suitlab",
+        name: "Suit Lab",
+        tagline: "Индивидуальные тройки и монограмма на подкладе.",
+        price: 19000,
+        rating: 4.7,
+        reviews: 312,
+        image: MARKETPLACE_IMAGES[4],
+        location: "Санкт-Петербург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "attire-voguehouse",
+        name: "Vogue House",
+        tagline: "Винтажные коллекции и стилист по аксессуарам в аренду.",
+        price: 21000,
+        rating: 4.6,
+        reviews: 268,
+        image: MARKETPLACE_IMAGES[0],
+        location: "Ростов-на-Дону",
+        phone: MARKETPLACE_CONTACT_PHONE
+      }
+    ]
+  },
+  {
+    id: "hosts",
+    title: "Ведущие",
+    contractors: [
+      {
+        id: "host-andrey",
+        name: "Ведущий Андрей",
+        tagline: "Интеллигентный юмор, живой вокал и welcome для гостей.",
+        price: 20000,
+        rating: 4.9,
+        reviews: 803,
+        image: MARKETPLACE_IMAGES[3],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "host-ekaterina",
+        name: "Ведущая Екатерина",
+        tagline: "Сценарий без конкурсов, интерактивы с друзьями и родителями.",
+        price: 21000,
+        rating: 4.8,
+        reviews: 654,
+        image: MARKETPLACE_IMAGES[4],
+        location: "Санкт-Петербург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "host-mikhail",
+        name: "Ведущий Михаил",
+        tagline: "Командная работа с диджеем и внимание к таймингу.",
+        price: 19000,
+        rating: 4.7,
+        reviews: 512,
+        image: MARKETPLACE_IMAGES[0],
+        location: "Казань",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "host-valeria",
+        name: "Ведущая Валерия",
+        tagline: "Живой вокал, тонкий юмор и поддержка тайминга вечера.",
+        price: 21000,
+        rating: 4.9,
+        reviews: 562,
+        image: MARKETPLACE_IMAGES[4],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "host-artyom",
+        name: "Ведущий Артём",
+        tagline: "Современный сценарий без шаблонов и импровизация с гостями.",
+        price: 22000,
+        rating: 4.7,
+        reviews: 438,
+        image: MARKETPLACE_IMAGES[1],
+        location: "Екатеринбург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "host-nika",
+        name: "Ведущая Ника",
+        tagline: "Двухязычная подача и забота о каждой детали церемонии.",
+        price: 23000,
+        rating: 4.8,
+        reviews: 377,
+        image: MARKETPLACE_IMAGES[0],
+        location: "Сочи",
+        phone: MARKETPLACE_CONTACT_PHONE
+      }
+    ]
+  },
+  {
+    id: "djs",
+    title: "Диджеи",
+    contractors: [
+      {
+        id: "dj-skybeat",
+        name: "Диджей SkyBeat",
+        tagline: "Лайв миксы на саксофоне и плейлист под ваш first dance.",
+        price: 15000,
+        rating: 4.8,
+        reviews: 420,
+        image: MARKETPLACE_IMAGES[2],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "dj-neon",
+        name: "DJ Neon",
+        tagline: "House + pop mashup, световое шоу и фотозона с винилом.",
+        price: 13000,
+        rating: 4.6,
+        reviews: 311,
+        image: MARKETPLACE_IMAGES[1],
+        location: "Сочи",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "dj-luna",
+        name: "Диджей Luna",
+        tagline: "R&B-сеты на закате и ночная афтерпати до рассвета.",
+        price: 16000,
+        rating: 4.9,
+        reviews: 502,
+        image: MARKETPLACE_IMAGES[4],
+        location: "Санкт-Петербург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "dj-aurum",
+        name: "DJ Aurum",
+        tagline: "Deep-house сет с саксофоном и живыми mashup переходами.",
+        price: 17000,
+        rating: 4.8,
+        reviews: 389,
+        image: MARKETPLACE_IMAGES[3],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "dj-rio",
+        name: "DJ Rio",
+        tagline: "Латино-ритмы, перкуссия и афтерпати до рассвета.",
+        price: 15000,
+        rating: 4.6,
+        reviews: 274,
+        image: MARKETPLACE_IMAGES[0],
+        location: "Сочи",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "dj-pulse",
+        name: "DJ Pulse",
+        tagline: "Световое шоу, дым-машины и персональные треки гостей.",
+        price: 18000,
+        rating: 4.9,
+        reviews: 445,
+        image: MARKETPLACE_IMAGES[4],
+        location: "Санкт-Петербург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      }
+    ]
+  },
+  {
+    id: "jewelry",
+    title: "Ювелирные магазины",
+    contractors: [
+      {
+        id: "jewelry-aurora",
+        name: "Дом Aurora",
+        tagline: "Индивидуальные гравировки, платина и этичные камни.",
+        price: 30000,
+        rating: 4.9,
+        reviews: 1576,
+        image: MARKETPLACE_IMAGES[3],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "jewelry-northlight",
+        name: "NorthLight",
+        tagline: "Минималистичные кольца, русское золото и lifetime уход.",
+        price: 12000,
+        rating: 4.7,
+        reviews: 638,
+        image: MARKETPLACE_IMAGES[2],
+        location: "Санкт-Петербург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "jewelry-monogold",
+        name: "MonoGold",
+        tagline: "Лаб-гемы, кастомный оттенок металла и 3D-примерка.",
+        price: 15000,
+        rating: 4.8,
+        reviews: 452,
+        image: MARKETPLACE_IMAGES[0],
+        location: "Новосибирск",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "jewelry-atelierdeco",
+        name: "Atelier Déco",
+        tagline: "Комбинируем огранки, делаем 3D-примерку и индивидуальную посадку.",
+        price: 28000,
+        rating: 4.8,
+        reviews: 842,
+        image: MARKETPLACE_IMAGES[1],
+        location: "Москва",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "jewelry-serebro",
+        name: "Serebro & Co",
+        tagline: "Серебряные пары, эмаль и кастомные оттенки золота.",
+        price: 18000,
+        rating: 4.6,
+        reviews: 365,
+        image: MARKETPLACE_IMAGES[2],
+        location: "Казань",
+        phone: MARKETPLACE_CONTACT_PHONE
+      },
+      {
+        id: "jewelry-lumina",
+        name: "Lumina",
+        tagline: "Этичные камни, сертификаты GIA и пожизненный уход.",
+        price: 30000,
+        rating: 4.9,
+        reviews: 1298,
+        image: MARKETPLACE_IMAGES[4],
+        location: "Санкт-Петербург",
+        phone: MARKETPLACE_CONTACT_PHONE
+      }
+    ]
+  }
+];

--- a/styles.css
+++ b/styles.css
@@ -362,7 +362,9 @@ button.secondary:hover {
   display: grid;
   gap: 1.5rem;
   grid-template-columns: minmax(260px, 320px) minmax(360px, 1fr) minmax(260px, 320px);
-  grid-template-areas: "checklist tools budget";
+  grid-template-areas:
+    "checklist tools budget"
+    "marketplace marketplace marketplace";
   align-items: start;
   position: relative;
 }
@@ -394,6 +396,256 @@ button.secondary:hover {
 
 .dashboard-module[data-area="budget"] {
   grid-area: budget;
+}
+
+.dashboard-module[data-area="marketplace"] {
+  grid-area: marketplace;
+}
+
+.dashboard-module.marketplace {
+  gap: 1.75rem;
+  padding: 1.75rem;
+}
+
+.marketplace-content {
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
+  gap: 1.75rem;
+  align-items: start;
+}
+
+.marketplace-categories {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.marketplace-category {
+  border: none;
+  border-radius: 16px;
+  padding: 0.9rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  background: rgba(224, 122, 139, 0.12);
+  color: var(--txt);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  text-align: left;
+}
+
+.marketplace-category:hover,
+.marketplace-category:focus-visible {
+  background: rgba(224, 122, 139, 0.2);
+  transform: translateY(-1px);
+}
+
+.marketplace-category--active {
+  background: linear-gradient(135deg, var(--accent), #ffb4c3);
+  color: #fff;
+  box-shadow: 0 18px 34px rgba(224, 122, 139, 0.25);
+}
+
+.marketplace-category__name {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.marketplace-category__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.marketplace-category__icon {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.marketplace-category__count {
+  flex: 0 0 auto;
+  min-width: 2.4rem;
+  text-align: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  background: rgba(224, 122, 139, 0.18);
+  color: var(--accent-dark);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.marketplace-category--active .marketplace-category__count {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+.marketplace-cards {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.marketplace-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 20px;
+  box-shadow: 0 16px 36px rgba(47, 42, 59, 0.14);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  height: 100%;
+}
+
+.marketplace-card:hover,
+.marketplace-card:focus-within {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(47, 42, 59, 0.18);
+}
+
+.marketplace-card__image {
+  border-radius: 16px;
+  overflow: hidden;
+  aspect-ratio: 4 / 3;
+  background: #f7f5f8;
+  position: relative;
+}
+
+.marketplace-card__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.marketplace-card__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  flex: 1 1 auto;
+}
+
+.marketplace-card__price {
+  margin: 0;
+}
+
+.marketplace-card__price strong {
+  font-size: 1.2rem;
+  color: var(--accent-dark);
+}
+
+.marketplace-card__title {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.marketplace-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.marketplace-card__rating {
+  color: var(--accent-dark);
+}
+
+.marketplace-card__reviews {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.marketplace-card__location {
+  margin: 0;
+  font-weight: 600;
+  color: var(--accent-dark);
+}
+
+.marketplace-card__description {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.marketplace-card__actions {
+  margin-top: auto;
+}
+
+.marketplace-card__favorite {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 44px;
+  height: 44px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 12px 20px rgba(47, 42, 59, 0.18);
+  color: var(--accent-dark);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  z-index: 1;
+}
+
+.marketplace-card__favorite:hover,
+.marketplace-card__favorite:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(47, 42, 59, 0.22);
+}
+
+.marketplace-card__favorite[aria-pressed="true"] {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 18px 34px rgba(224, 122, 139, 0.35);
+}
+
+.marketplace-card__favorite-icon {
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.marketplace-card__action {
+  width: 100%;
+  border: none;
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.marketplace-card__action:hover,
+.marketplace-card__action:focus-visible {
+  background: #d96678;
+  box-shadow: 0 14px 26px rgba(224, 122, 139, 0.32);
+  transform: translateY(-1px);
+}
+
+.marketplace-empty {
+  margin: 0;
+  padding: 2.5rem 1.5rem;
+  border-radius: 20px;
+  background: rgba(224, 122, 139, 0.08);
+  color: var(--muted);
+  font-weight: 600;
+  text-align: center;
+}
+
+.marketplace-empty--favorites {
+  background: rgba(224, 122, 139, 0.12);
 }
 
 .dashboard-module.checklist {
@@ -1167,6 +1419,39 @@ body.checklist-expanded {
   transform: scale(1);
 }
 
+.modal-phone {
+  margin: 1.25rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.modal-phone__label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.modal-phone__value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--accent-dark);
+  text-decoration: none;
+}
+
+.modal-phone__value:hover,
+.modal-phone__value:focus-visible {
+  text-decoration: underline;
+}
+
+.modal-note {
+  margin: 0.75rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
 #confetti-canvas {
   position: fixed;
   inset: 0;
@@ -1190,13 +1475,37 @@ body.checklist-expanded {
     grid-template-columns: minmax(260px, 1fr) minmax(260px, 1fr);
     grid-template-areas:
       "checklist tools"
-      "budget budget";
+      "budget budget"
+      "marketplace marketplace";
   }
 
   .dashboard-module.checklist--expanded {
     width: min(640px, 92vw);
     height: min(82vh, 640px);
     padding: 1.75rem;
+  }
+
+  .marketplace-content {
+    grid-template-columns: minmax(200px, 1fr) minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 900px) {
+  .marketplace-content {
+    grid-template-columns: 1fr;
+  }
+
+  .marketplace-categories {
+    flex-direction: row;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+    margin: 0 -0.35rem;
+    gap: 0.6rem;
+  }
+
+  .marketplace-category {
+    flex: 0 0 auto;
+    min-width: 210px;
   }
 }
 
@@ -1228,7 +1537,8 @@ body.checklist-expanded {
     grid-template-areas:
       "tools"
       "checklist"
-      "budget";
+      "budget"
+      "marketplace";
   }
 
   .dashboard-module.checklist--expanded {
@@ -1307,5 +1617,26 @@ body.checklist-expanded {
   .actions button,
   .budget-form button {
     width: 100%;
+  }
+
+  .marketplace-content {
+    grid-template-columns: 1fr;
+  }
+
+  .marketplace-categories {
+    flex-direction: row;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+    margin: 0 -0.35rem;
+    gap: 0.5rem;
+  }
+
+  .marketplace-category {
+    flex: 0 0 auto;
+    min-width: 200px;
+  }
+
+  .marketplace-card {
+    padding: 1.1rem;
   }
 }


### PR DESCRIPTION
## Summary
- randomize marketplace cards and surface a favorites category with persistent toggles
- add phone reveal interactions and heart buttons to contractor cards tied to the modal
- extend vendor data with contact numbers, richer samples, and styling updates for the new controls

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d244a6be3c8324b2ff90bddd4dcb08